### PR TITLE
Fix parallel property import

### DIFF
--- a/PAMELA/source/Collection/Collection.hpp
+++ b/PAMELA/source/Collection/Collection.hpp
@@ -205,10 +205,11 @@ namespace PAMELA
 		}
 
 		//Groups
-		void addAndCreateGroup(std::string label) { m_labelToGroup[label] = new ElementEnsemble<T, ElementHash<T>, ElementEqual<T>>(); }
+		void addAndCreateGroup(std::string label) { int const size = m_labelToGroup.size(); m_labelToGroup[label] = new ElementEnsemble<T, ElementHash<T>, ElementEqual<T>>(); m_labelToPosition[label] = size;}
 		void MakeActiveGroup(std::string label) { ASSERT(groupExist(label), "The group does not exist"); m_activeGroup[label] = true; }
 		std::unordered_map<std::string, bool>& get_ActiveGroupsMap() { return m_activeGroup; }
 		std::unordered_map<std::string, ElementEnsemble<T, ElementHash<T>, ElementEqual<T>>*>& get_labelToGroupMap() { return m_labelToGroup; }
+	        std::unordered_map<std::string, int>& get_labelToPositionMap() { return m_labelToPosition; }
 		ElementEnsemble<T, ElementHash<T>, ElementEqual<T>>* get_Group(std::string label) { ASSERT(groupExist(label), "The group does not exist"); return m_labelToGroup.at(label); }
 
 		//Parallel
@@ -222,6 +223,7 @@ namespace PAMELA
 		//Groups
 		bool groupExist(std::string label) { return m_labelToGroup.count(label) == 1; }
 		std::unordered_map<std::string, ElementEnsemble<T, ElementHash<T>, ElementEqual<T>>*> m_labelToGroup;
+ 	        std::unordered_map<std::string, int> m_labelToPosition;
 		std::unordered_map<std::string, bool> m_activeGroup;
 
 	};

--- a/PAMELA/source/MeshDataWriters/MeshParts.cpp
+++ b/PAMELA/source/MeshDataWriters/MeshParts.cpp
@@ -115,6 +115,8 @@ namespace PAMELA {
       for (auto& mesh_prop : mesh_props)
       {
         auto values = mesh_prop.second;
+        std::cout <<Communicator::worldRank() << " >> VALUES SIZE OWNED" << values.size_owned() << std::endl;
+        std::cout <<Communicator::worldRank() << " >> VALUES SIZE GHOST" << values.size_ghost() << std::endl;
         auto dim = mesh->get_PolyhedronProperty_double()->GetProperty_dimension(mesh_prop.first);
         int dimInt = static_cast< int >( dim );
         auto var = curPart->AddVariable( dim, VARIABLE_LOCATION::PER_CELL,mesh_prop.first);
@@ -134,7 +136,15 @@ namespace PAMELA {
             auto globalIndex = cellPtr->get_globalIndex();
             for(int i = 0; i < dimInt; i++)
             {
-              values_in_part[localIndex2*dimInt+i] = values[globalIndex*dimInt+i];
+              values_in_part[localIndex2*dimInt+i] = values[localIndex2*dimInt+i];
+              if( mesh_prop.first == "PORO" )
+              {
+                std::cout << Communicator::worldRank() << " >> localIndex2 " << localIndex2 << std::endl;
+                std::cout << Communicator::worldRank() << " >> dimint " << dimInt << std::endl;
+                std::cout << Communicator::worldRank() << " >> globalIndex " << globalIndex << std::endl;
+                std::cout << Communicator::worldRank() << " >> i " << i << std::endl;
+                std::cout << Communicator::worldRank() << " >> putting " <<  values[globalIndex*dimInt+i] << " in " << localIndex2*dimInt+i << std::endl;
+              }
             }
           }
         }


### PR DESCRIPTION
This PR fixes the parallel import of a property (for instance, porosity, permeability). If the domain includes multiple regions, the current implementation assumes that the cells are grouped by region in the msh file.

@AntoineMazuyer with these modifications, here is a summary of what works:
- If the mesh includes only one region, the parallel import of a property is now working. In particular, we can now run in parallel tutorials 4 and 5.
- If the mesh includes multiple regions, the import of a property is working provided that the cells are grouped by region in the msh file. When I reorder the cells in the toy_model.msh file used in `testPAMELAImport.cpp` to group them by region (see PR https://github.com/GEOSX/GEOSX/pull/1240), I can load the property in parallel and everything seems to be working fine.

Now, should I modify the class that reads the msh files (in `Import/Gmsh_mesh.cpp`) to make sure that we can also deal with files in which the cells are not grouped by region? (I may do it in a separate PR)